### PR TITLE
fix: dark mode org overlay

### DIFF
--- a/components/OrganisingGroup.tsx
+++ b/components/OrganisingGroup.tsx
@@ -34,18 +34,18 @@ export const OrganisingGroupDialog = (
       <Dialog
         open={!!data}
         onClose={onClose}
-        className="fixed z-40 inset-0 overflow-y-auto"
+        className="fixed z-40 inset-0 overflow-y-auto dark:text-white"
       >
         {!!data && (
           <>
             <OrganisingGroupSEO data={data} />
-            <Dialog.Overlay className="fixed z-10 inset-0 bg-dark opacity-80" />
+            <Dialog.Overlay className="fixed z-10 inset-0 bg-dark opacity-90" />
             <div className='absolute z-20 w-full max-w-4xl top-[15%] left-1/2 transform -translate-x-1/2 py-5 p-4'>
               <Dialog.Title className='hidden'>{data.fields.Name}</Dialog.Title>
               <Dialog.Description className='hidden'>{data.fields.IsUnion ? "Union" : "NGO"} in {stringifyArray(...data.fields?.countryNames || [])}</Dialog.Description>
               <button
                 type="button"
-                className="mb-3 rounded-xl px-2 py-1 border-box"
+                className="mb-3 rounded-xl px-2 py-1 border-box dark:text-white"
                 onClick={onClose}
               >
                 &larr; Back
@@ -73,7 +73,7 @@ export const OrganisingGroupCard = ({ data, withPadding = true, withContext = tr
   console.log(data.fields)
   return (
     <>
-      <article className={cx('space-y-2px rounded-xl overflow-hidden')}>
+      <article className={cx('space-y-2px rounded-xl overflow-hidden dark:text-white')}>
         <div className={cx(withPadding && 'md:px-8', 'p-4 bg-white dark:bg-black dark:text-white')}>
           <div className='text-sm'>
             <div className='flex flex-wrap tracking-tight'>
@@ -129,12 +129,12 @@ export const OrganisingGroupCard = ({ data, withPadding = true, withContext = tr
             </div>
           </div>
         </div>
-        <div className={cx(withPadding && 'md:px-8', 'p-4 bg-white dark:bg-black')}>
+        <div className={cx(withPadding && 'md:px-8', 'p-4 bg-white dark:bg-black dark:text-white')}>
           Have more info about this {data.fields.IsUnion ? "union" : "ngo"}? <a className='link' href={`mailto:${projectStrings.email}`}>Let us know &rarr;</a>
         </div>
         {withContext && (
           <div className='grid gap-[2px] grid-cols-2'>
-            <div className={cx(withPadding && 'md:px-8', 'p-4 bg-white dark:bg-black')}>
+            <div className={cx(withPadding && 'md:px-8', 'p-4 bg-white dark:bg-black dark:text-white')}>
               <SolidarityActionRelatedActions
                 name={data.fields.Name}
                 metadata={pluralize('related action', data.fields["Solidarity Actions"]?.length, true)}


### PR DESCRIPTION
Fixes a bug where the org overlay in dark mode shows an unreadable text colour

current in production:
![image](https://user-images.githubusercontent.com/1368727/204166626-89e4eaa0-86b9-4f43-a7dd-3b3c531972e4.png)

fixed:
![image](https://user-images.githubusercontent.com/1368727/204166676-da26bbd9-8624-4102-9d78-669f0925b730.png)


## Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If there's a Figma file or similar spec, please link to to the issue. -->

## Testing / QA plan
<!--- Please describe in detail how you tested your changes so that a reviewer can reproduce the results. -->
<!--- Include details of your testing environment, and the tests you've run your self -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've checked the spec (e.g. Figma file) and documented any divergences.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.